### PR TITLE
Utils friendly

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -185,8 +185,9 @@ func (x *Generator) Write(wr io.Writer) error {
 	// Write package and import
 	fmt.Fprintf(writer, "package %s\n\n", p)
 	fmt.Fprintln(writer, "import (")
-	fmt.Fprintln(writer, "\t\"github.com/jessevdk/go-assets\"")
 	fmt.Fprintln(writer, "\t\"time\"")
+	fmt.Fprintln(writer)
+	fmt.Fprintln(writer, "\t\"github.com/jessevdk/go-assets\"")
 	fmt.Fprintln(writer, ")")
 	fmt.Fprintln(writer)
 

--- a/generate.go
+++ b/generate.go
@@ -220,7 +220,7 @@ func (x *Generator) Write(wr io.Writer) error {
 			s := sha1.New()
 			io.WriteString(s, k)
 
-			vname := fmt.Sprintf("__%s%x", variableName, s.Sum(nil))
+			vname := fmt.Sprintf("_%s%x", variableName, s.Sum(nil))
 			vnames[k] = vname
 
 			fmt.Fprintf(writer, "var %s = %#v\n", vname, string(data))
@@ -229,6 +229,7 @@ func (x *Generator) Write(wr io.Writer) error {
 		fmt.Fprintln(writer)
 	}
 
+	fmt.Fprintf(writer, "// %s returns go-assets FileSystem\n", variableName)
 	fmt.Fprintf(writer, "var %s = assets.NewFileSystem(", variableName)
 
 	if x.fsDirsMap == nil {


### PR DESCRIPTION
to pass `go vet` and `goimport` :)

this is not necessarily patch. we can skip generated code for both tools.

---

test with:

* go version go1.7 linux/amd64
* https://github.com/jessevdk/go-assets 1331bd4f9b36aa51f8a7c4ac007792287cf63cb8
* https://github.com/golang/lint c7bacac2b21ca01afa1dee0acf64df3ce047c28f
* https://go.googlesource.com/tools 3f4088edb48e8a4e3c66a5f8e7b2a78615fcb83f