### PR TITLE
Gotag

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -23,8 +23,8 @@ type FileSystem struct {
 
 func NewFileSystem(dirs map[string][]string, files map[string]*File, localPath string) *FileSystem {
 	fs := &FileSystem{
-		Dirs: dirs,
-		Files: files,
+		Dirs:      dirs,
+		Files:     files,
 		LocalPath: localPath,
 	}
 

--- a/generate.go
+++ b/generate.go
@@ -31,6 +31,9 @@ type Generator struct {
 	// Strip the specified prefix from all paths,
 	StripPrefix string
 
+	// Tags for build constraints
+	Tags string
+
 	fsDirsMap  map[string][]string
 	fsFilesMap map[string]file
 }
@@ -181,6 +184,10 @@ func (x *Generator) Write(wr io.Writer) error {
 	}
 
 	writer := &bytes.Buffer{}
+
+	if x.Tags != "" {
+		fmt.Fprintf(writer, "// +build %s\n\n", x.Tags)
+	}
 
 	// Write package and import
 	fmt.Fprintf(writer, "package %s\n\n", p)


### PR DESCRIPTION
Add build-constraints `+build` with -t flag. This is useful to make hybrid apps that can be built static/non-static.