### PR TITLE
Add "Prefix" as path prefix of file service

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -19,6 +19,8 @@ type FileSystem struct {
 
 	// Override loading assets from local path. Useful for development.
 	LocalPath string
+	// Prefix would be prepended to http requests
+	Prefix string
 }
 
 func NewFileSystem(dirs map[string][]string, files map[string]*File, localPath string) *FileSystem {
@@ -50,6 +52,9 @@ func (f *FileSystem) NewFile(path string, filemode os.FileMode, mtime time.Time,
 func (f *FileSystem) Open(p string) (http.File, error) {
 	p = path.Clean(p)
 
+	if len(f.Prefix) !=0 {
+		p = path.Join(f.Prefix, p)
+	}
 	if len(f.LocalPath) != 0 {
 		return http.Dir(f.LocalPath).Open(p)
 	}


### PR DESCRIPTION
### file structure:
* main.go
* data
    * page
        * js
        * img
        * css
        * index.html
    * database
        * data.db

### main.go:
```golang
func main(){
    router := gin.Default()
    asset.Assets.Prefix="/data/page"
    router.StaticFS("/page", asset.Assets)
}
```