### PR TITLE
fix panic: runtime error: makeslice: cap out of range

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -23,8 +23,8 @@ type FileSystem struct {
 
 func NewFileSystem(dirs map[string][]string, files map[string]*File, localPath string) *FileSystem {
 	fs := &FileSystem{
-		Dirs: dirs,
-		Files: files,
+		Dirs:      dirs,
+		Files:     files,
 		LocalPath: localPath,
 	}
 
@@ -71,13 +71,18 @@ func (f *FileSystem) Open(p string) (http.File, error) {
 
 func (f *FileSystem) readDir(p string, index int, count int) ([]os.FileInfo, error) {
 	if d, ok := f.Dirs[p]; ok {
-		maxl := index + count
-
+		maxl := len(d)
+		if count > 0 {
+			maxl = index + count
+		}
 		if maxl > len(d) {
 			maxl = len(d)
 		}
-
-		ret := make([]os.FileInfo, 0, maxl-index)
+		capacity := maxl
+		if index > 0 {
+			capacity -= index
+		}
+		ret := make([]os.FileInfo, 0, capacity)
 
 		for i := index; i < maxl; i++ {
 			ret = append(ret, f.Files[path.Join(p, d[i])])


### PR DESCRIPTION
When count -1 is passed to readDir, it panics currently.